### PR TITLE
Set auto replication of sgadmin index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ENV KEYSTORE_PATH=/keys/keystore.jks
 ENV TRUSTSTORE_PATH=/keys/truststore.jks
 ENV SG_CONFIG_PATH=/sgconfig
 ENV WAIT_TIME_SECS=420
-ENV SGADMIN_EXTRA_ARGS='-nhnv -icl -era'
+ENV SGADMIN_EXTRA_ARGS='-nhnv -icl'
+ENV ENABLE_AUTO_SGINDEX_REPLICATE=true
 ENV ES_HOSTNAME=elasticsearch-discovery
 ENV ES_PORT=9300
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Launch the container with the following properties:
 * TRUSTSTORE_PASSWORD: The password for the truststore (required)
 * SG_CONFIG_PATH: The full path to the directory containing the [search guard configuration](http://floragunncom.github.io/search-guard-docs/configuration.html) that should be used to configure the cluster (Default: /sgconfig)
 * WAIT_TIME_SECS: The time to wait (s) before attempting to connect to the cluster. This allows for cluster boot if launching this container at the same time (Default: 420)
-* SGADMIN_EXTRA_ARGS: Any additional Search Guard command line arguments. See [configuration options](http://floragunncom.github.io/search-guard-docs/sgadmin.html) (Default: '-nhnv -icl -era')
+* SGADMIN_EXTRA_ARGS: Any additional Search Guard command line arguments. See [configuration options](http://floragunncom.github.io/search-guard-docs/sgadmin.html) (Default: '-nhnv -icl')
+* ENABLE_AUTO_SGINDEX_REPLICATE: Call sgadmin a second time with -era to enable auto replication of the sgindex to new nodes (Default: true)
 * ES_HOSTNAME: The elasticsearch hostname (Default: elasticsearch-discovery)
 * ES_PORT: The elasticsearch port (Default: 9300)
 ### Volumes Required

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,23 @@
-#!/bin/sh
+#!/bin/bash
+
+# Check non-defaulted required variables have been set
+if [ -z ${KEYSTORE_PASSWORD+x} ]; then
+  echo "Please set the KEYSTORE_PASSWORD environment variable"
+  exit 1
+fi
+if [ -z ${TRUSTSTORE_PASSWORD+x} ]; then
+  echo "Please set the TRUSTSTORE_PASSWORD environment variable"
+  exit 1
+fi
 
 echo "Waiting $WAIT_TIME_SECS seconds before trying to initialize search guard."
 sleep $WAIT_TIME_SECS
+
 echo "Initializing search guard.."
 cd $SG_CONFIG_PATH
 /sgadmin/tools/sgadmin.sh -ks $KEYSTORE_PATH -ts $TRUSTSTORE_PATH -kspass $KEYSTORE_PASSWORD -tspass $TRUSTSTORE_PASSWORD -h $ES_HOSTNAME -p $ES_PORT $SGADMIN_EXTRA_ARGS
+
+if [ $? -eq 0 ] && [[ $ENABLE_AUTO_SGINDEX_REPLICATE == "true" ]]; then
+  echo "Enabling sgindex auto replication"
+  /sgadmin/tools/sgadmin.sh -ks $KEYSTORE_PATH -ts $TRUSTSTORE_PATH -kspass $KEYSTORE_PASSWORD -tspass $TRUSTSTORE_PASSWORD -h $ES_HOSTNAME -p $ES_PORT $SGADMIN_EXTRA_ARGS -era
+fi


### PR DESCRIPTION
The Search Guard index is initialized on all the nodes when the index is first created but not on any new nodes that subsequently join the cluster. This adds the option to add auto-replication of the search guard index to new nodes (defaulted to true).